### PR TITLE
counter from basehub

### DIFF
--- a/app/_components/views-fragment.tsx
+++ b/app/_components/views-fragment.tsx
@@ -1,6 +1,9 @@
 import { unstable_noStore } from 'next/cache'
 import { draftMode } from 'next/headers'
 import { basehub } from 'basehub'
+import { Transaction } from 'basehub/api-transaction'
+
+const hardcodedIdToTest = '8e781486e3173290933ba'
 
 export const ViewsFragment = async ({
   postId,
@@ -12,7 +15,7 @@ export const ViewsFragment = async ({
   unstable_noStore()
   const { isEnabled: isDraftMode } = draftMode()
 
-  const viewsQueryPromise = basehub().query({
+  const viewsQueryPromise = basehub({ draft: true }).query({
     index: {
       postsSection: {
         posts: {
@@ -32,8 +35,8 @@ export const ViewsFragment = async ({
         __args: {
           data: JSON.stringify({
             type: 'update',
-            data: { type: 'number:incr', data: { id: postId } },
-          }),
+            data: { type: 'number:incr', id: hardcodedIdToTest },
+          } satisfies Transaction),
         },
       },
     })

--- a/app/_components/views-fragment.tsx
+++ b/app/_components/views-fragment.tsx
@@ -1,6 +1,6 @@
 import { unstable_noStore } from 'next/cache'
-import { redis } from '../redis'
 import { draftMode } from 'next/headers'
+import { basehub } from 'basehub'
 
 export const ViewsFragment = async ({
   postId,
@@ -12,12 +12,37 @@ export const ViewsFragment = async ({
   unstable_noStore()
   const { isEnabled: isDraftMode } = draftMode()
 
-  let views: null | number = null
+  const viewsQueryPromise = basehub().query({
+    index: {
+      postsSection: {
+        posts: {
+          __args: { filter: { _sys_id: { eq: postId } } },
+          items: {
+            views: true,
+          },
+        },
+      },
+    },
+  })
+
+  let incr = 0
   if (increment && !isDraftMode) {
-    views = await redis.incr(`views:${postId}`)
-  } else {
-    views = await redis.get(`views:${postId}`)
+    await basehub().mutation({
+      transaction: {
+        __args: {
+          data: JSON.stringify({
+            type: 'update',
+            data: { type: 'number:incr', data: { id: postId } },
+          }),
+        },
+      },
+    })
+    incr++
   }
+
+  const views =
+    ((await viewsQueryPromise).index.postsSection.posts.items[0]?.views ?? 0) +
+    incr
 
   return <>{views || '0'}</>
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -169,7 +169,7 @@ const PostPage = async ({ params }: { params: { slug: string } }) => {
                       ·{' '}
                       <ViewsFragment
                         postId={post._id}
-                        increment={process.env.NODE_ENV !== 'development'}
+                        increment //={process.env.NODE_ENV !== 'development'}
                       />{' '}
                       Views
                     </Suspense>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^0.1.11
     version: 0.1.11(next@14.1.1-canary.62)(react@18.2.0)
   basehub:
-    specifier: 3.0.5-next.1
-    version: 3.0.5-next.1(react-dom@18.2.0)(react@18.2.0)
+    specifier: 3.0.5
+    version: 3.0.5(react-dom@18.2.0)(react@18.2.0)
   clsx:
     specifier: ^2.0.0
     version: 2.0.0
@@ -805,8 +805,8 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
 
-  /basehub@3.0.5-next.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-13didypR3Os3QBhzpqfgiqXEDr41llT3mKHtejX70zTvPGUBnzZAD4h2lzOVChdEt71TTWyo9k6eGP5mI3W7cw==}
+  /basehub@3.0.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-0Mhh4Yi5umZGF6KxF86txYkTCcFXycIjDw2mS4JjHNP5+YBT9HmVxFl0YzLpfNVZGIN4161ke9XKT20HBaKFaA==}
     hasBin: true
     peerDependencies:
       react: ^18.2.0


### PR DESCRIPTION
this won't merge, but two insights from this exercise:
1. we'll need "mutable blocks". e.g, a "mutable counter" (or "live counter"), a "comment box", a "form". We cannot expect people to `commit` for every "view increment", nor should we expect them to use the `draft` api, nor our transaction api has the throughput necessary to support a view counter with decent update times
2. our Transaction API should leverage `api names` more instead of relying on IDs. currently, there's no way of getting the IDs of a primitive block via API